### PR TITLE
Add admin user and campaign modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -179,6 +179,65 @@
             </form>
         </div>
     </div>
+    <div id="addUserModal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title">Novo Usuário</h2>
+                <button class="close-btn" onclick="closeModal('addUserModal')">&times;</button>
+            </div>
+            <form id="addUserForm">
+                <div class="form-group">
+                    <label class="form-label">Nome</label>
+                    <input type="text" id="newUserName" class="input" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Email</label>
+                    <input type="email" id="newUserEmail" class="input" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Senha</label>
+                    <input type="password" id="newUserPassword" class="input" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Role</label>
+                    <select id="newUserRole" class="input">
+                        <option value="USER">Usuário</option>
+                        <option value="USER_SDR">User SDR</option>
+                        <option value="USER_VENDEDOR">User Vendedor</option>
+                        <option value="MR_RESPONSAVEL">MR Responsável</option>
+                        <option value="ADMIN_OPERACIONAL">Admin Operacional</option>
+                        <option value="ADMIN_CONTEUDO">Admin Conteúdo</option>
+                        <option value="ADMIN_GAMIFICACAO">Admin Gamificação</option>
+                        <option value="SUPER_ADMIN">Super Admin</option>
+                    </select>
+                </div>
+                <button type="submit" class="btn btn-primary">Criar</button>
+            </form>
+        </div>
+    </div>
+    <div id="addCampaignModal" class="modal hidden">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2 class="modal-title">Nova Campanha</h2>
+                <button class="close-btn" onclick="closeModal('addCampaignModal')">&times;</button>
+            </div>
+            <form id="addCampaignForm">
+                <div class="form-group">
+                    <label class="form-label">Nome</label>
+                    <input type="text" id="campaignName" class="input" required>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Descrição</label>
+                    <textarea id="campaignDescription" class="input" required></textarea>
+                </div>
+                <div class="form-group">
+                    <label class="form-label">Meta (R$)</label>
+                    <input type="number" id="campaignGoal" class="input" required>
+                </div>
+                <button type="submit" class="btn btn-primary">Salvar</button>
+            </form>
+        </div>
+    </div>
  <script src="config.js"></script>
 <script src="main.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -2171,6 +2171,43 @@ px; background: var(--primary); border-radius: 50%; display: flex; align-items: 
             }
 
             const feedbackForm = document.getElementById('feedbackForm');
+            const userForm = document.getElementById('addUserForm');
+            if (userForm) {
+                userForm.addEventListener('submit', async (e) => {
+                    e.preventDefault();
+                    try {
+                        const createUser = firebase.functions().httpsCallable('createUser');
+                        await createUser({
+                            email: document.getElementById('newUserEmail').value,
+                            password: document.getElementById('newUserPassword').value,
+                            displayName: document.getElementById('newUserName').value,
+                            role: document.getElementById('newUserRole').value
+                        });
+                        userForm.reset();
+                        closeModal('addUserModal');
+                        showNotification('Usuário criado com sucesso', 'success');
+                    } catch (err) {
+                        console.error('Erro ao criar usuário', err);
+                        showNotification('Erro ao criar usuário', 'error');
+                    }
+                });
+            }
+
+            const campaignForm = document.getElementById('addCampaignForm');
+            if (campaignForm) {
+                campaignForm.addEventListener('submit', async (e) => {
+                    e.preventDefault();
+                    await db.collection('campaigns').add({
+                        name: document.getElementById('campaignName').value,
+                        description: document.getElementById('campaignDescription').value,
+                        goal: parseFloat(document.getElementById('campaignGoal').value),
+                        createdAt: firebase.firestore.FieldValue.serverTimestamp()
+                    });
+                    campaignForm.reset();
+                    closeModal('addCampaignModal');
+                    showNotification('Campanha criada', 'success');
+                });
+            }
             if (feedbackForm) {
                 feedbackForm.addEventListener('submit', async (e) => {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
- add new user and campaign forms in `index.html`
- support user creation via new `createUser` cloud function
- add handlers for new forms in main script

## Testing
- `npm test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686c00088f58832fab218258b52101ea