### PR TITLE
Fix createUser CORS

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -87,7 +87,10 @@ exports.updateUserRole = onCall(
 
 // Função callable para criação de usuários por administradores
 exports.createUser = onCall(
-  {region: "us-central1"},
+  {
+    region: "us-central1",
+    cors: true,
+  },
   async (req) => {
     const callerRole = req.auth && req.auth.token ? req.auth.token.role : null;
     if (callerRole !== "SUPER_ADMIN") {


### PR DESCRIPTION
## Summary
- allow CORS requests when invoking the `createUser` function

## Testing
- `npm test` *(fails: jest Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686c16f22998832f83fbc5923433050a